### PR TITLE
State keypoint

### DIFF
--- a/capstone-project/src/components/ModelContext.tsx
+++ b/capstone-project/src/components/ModelContext.tsx
@@ -27,7 +27,7 @@ export const ModelProvider: React.FunctionComponent<ModelProvider> = ({ children
 export function useModelContext() {
     const context = useContext(ModelContext);
     if (context == undefined){
-        throw new Error ('error');
+        throw new Error ('Error on Model Context');
     }
     return context;
 }

--- a/capstone-project/src/components/ModelDisplay.tsx
+++ b/capstone-project/src/components/ModelDisplay.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useEffect, useCallback, useContext, useState } from 'rea
 import { Canvas, useThree, extend, ThreeEvent } from '@react-three/fiber';
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader';
 import { OrbitControls } from '@react-three/drei';
-import {Mesh,MeshStandardMaterial,BufferGeometry,WireframeGeometry,LineSegments,LineBasicMaterial } from 'three';
+import { Mesh, MeshStandardMaterial, BufferGeometry, WireframeGeometry, LineSegments, LineBasicMaterial } from 'three';
 import ModelContext from './ModelContext';
 import * as THREE from 'three';
 import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils';
@@ -16,13 +16,13 @@ type ModelDisplayProps = {
 };
 
 const ModelContent: React.FC<ModelDisplayProps> = ({ modelData }) => {
-  const { tool, color } = useContext(ModelContext);//get the tool and color state from siderbar
+  const { tool, color } = useContext(ModelContext); // Get the tool and color state from sidebar
   const { camera, gl } = useThree();
   const meshRef = useRef<Mesh>(null);
   const wireframeRef = useRef<LineSegments>(null);
-  const [isSpray,setIsSpray] = useState(false);
+  const [isSpray, setIsSpray] = useState(false);
   const raycasterRef = useRef(new THREE.Raycaster());
-  const {states, setState, modelId,setModelId} = useModelStore();
+  const { states, keypoints, setState, modelId, setModelId } = useModelStore();
   const sprayRadius = 1;
 
   useEffect(() => {
@@ -33,158 +33,173 @@ const ModelContent: React.FC<ModelDisplayProps> = ({ modelData }) => {
 
     const modelID = modelData.byteLength.toString();
     if (!geometry.index) {
-      geometry = BufferGeometryUtils.mergeVertices(geometry);// merge the vertex to optimise the performance
+      geometry = BufferGeometryUtils.mergeVertices(geometry); // Merge the vertex to optimize performance
       geometry.computeVertexNormals();
     }
 
-
-    //use the BVH to accelerate the geometry
+    // Use the BVH to accelerate the geometry
     geometry.computeBoundsTree = computeBoundsTree;
     geometry.disposeBoundsTree = disposeBoundsTree;
     meshRef.current.raycast = acceleratedRaycast;
     geometry.computeBoundsTree();
 
-    // get all vertex and add the color about the vertex
+    // Get all vertices and initialize colors (default to white)
     const vertexCount = geometry.attributes.position.count;
-    // initialise the color, and default be white
     const colors = new Float32Array(vertexCount * 3).fill(1);
 
-    //load the saved states of color
-    const savedData = states[modelId] || {};
-    
-    if(savedData){
-      Object.keys(savedData).forEach( index => {
-        const color = new THREE.Color(savedData[Number(index)].color);
+    // Load the saved states of color
+    const savedData = states[modelId] || {}; // Default to empty object if no saved data exists
+
+    // Check if there are any spray annotations
+    const hasSprayAnnotations = Object.keys(savedData).some(
+      (index) => savedData[Number(index)]?.color // Check if color exists in any savedData entry
+    );
+
+    // If there are spray annotations, apply the colors to the vertices
+    if (hasSprayAnnotations) {
+      Object.keys(savedData).forEach((index) => {
+        const color = new THREE.Color(savedData[Number(index)]?.color || '#ffffff'); // Default to white if color is missing
         colors[Number(index) * 3] = color.r;
-        colors[Number(index)*3+1] = color.g;
-        colors[Number(index) *3+2] = color.b;
-    });
+        colors[Number(index) * 3 + 1] = color.g;
+        colors[Number(index) * 3 + 2] = color.b;
+      });
+    }
+
+    // Load keypoints and add spheres at the saved positions
+    const savedKeypoints = keypoints[modelId] || []; // Default to empty array if no keypoints exist
+    if (savedKeypoints.length > 0) {
+      savedKeypoints.forEach(({ position, color }) => {
+        if (position && color) { // Ensure both position and color are valid
+          const keypointSphere = new THREE.Mesh(
+            new THREE.SphereGeometry(0.05, 16, 16),
+            new THREE.MeshBasicMaterial({ color })
+          );
+          keypointSphere.position.set(position.x, position.y, position.z);
+          meshRef.current.add(keypointSphere);
+        }
+      });
     }
 
     setModelId(modelID);
 
-
-    // add the color into geometry, each vertex use three data to record color
-    geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    // Only set colors in geometry if there are spray annotations
+    if (hasSprayAnnotations) {
+      geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    }
 
     meshRef.current.geometry = geometry;
     meshRef.current.material = new MeshStandardMaterial({ vertexColors: true });
 
-    //add the mesh effect to model
+    // Add the mesh effect to model
     const wireframeGeometry = new WireframeGeometry(geometry);
     wireframeRef.current.geometry = wireframeGeometry;
   }, [modelData]);
 
-  const spray = useCallback((position : THREE.Vector2) => {
-    
+  const spray = useCallback((position: THREE.Vector2) => {
     if (!meshRef.current || !meshRef.current.geometry.boundsTree) return;
     const raycaster = raycasterRef.current;
     const geometry = meshRef.current.geometry as BufferGeometry;
     const colorAttributes = geometry.attributes.color as THREE.BufferAttribute;
     const newColor = new THREE.Color(color);
-    raycaster.setFromCamera(position,camera);
+    raycaster.setFromCamera(position, camera);
 
     const intersects = raycaster.intersectObject(meshRef.current, true);
 
-    if(intersects.length>0){
-        intersects.forEach((intersect: THREE.Intersection) => {
-          if(intersect.face){
-            const faceIndices = [intersect.face.a,intersect.face.b,intersect.face.c];
-            faceIndices.forEach(index => {
-              colorAttributes.setXYZ(index,newColor.r,newColor.g,newColor.b);
-              setState(modelId,index,color);
-            });
-            colorAttributes.needsUpdate = true;
-          }
-        })
+    if (intersects.length > 0) {
+      intersects.forEach((intersect: THREE.Intersection) => {
+        if (intersect.face) {
+          const faceIndices = [intersect.face.a, intersect.face.b, intersect.face.c];
+          faceIndices.forEach(index => {
+            colorAttributes.setXYZ(index, newColor.r, newColor.g, newColor.b);
+            setState(modelId, index, color);
+          });
+          colorAttributes.needsUpdate = true;
+        }
+      });
     }
-  },[color,camera]);
+  }, [color, camera]);
 
-  const handleMouseDown = useCallback((event : ThreeEvent<PointerEvent>) => {
-    if(tool != 'spray') return;
+  const handleMouseDown = useCallback((event: ThreeEvent<PointerEvent>) => {
+    if (tool !== 'spray') return;
     event.stopPropagation();
     setIsSpray(true);
-  },[gl,spray]);
+  }, [gl, spray]);
 
-  const handleMouseMove = useCallback((event : ThreeEvent<PointerEvent>) => {
-    //only spray when tool is spray and click the mouse
-    if(!isSpray || tool !== 'spray') return;
+  const handleMouseMove = useCallback((event: ThreeEvent<PointerEvent>) => {
+    // Only spray when tool is spray and click the mouse
+    if (!isSpray || tool !== 'spray') return;
     event.stopPropagation();
 
-    // get the weight and height from canvas
+    // Get the width and height from the canvas
     const rect = gl.domElement.getBoundingClientRect();
-    //transfer to NDC
+    // Transfer to NDC
     const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
     const y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
 
-    const point = new THREE.Vector2(x,y);
+    const point = new THREE.Vector2(x, y);
 
     spray(point);
-  },[isSpray,gl,spray]);
+  }, [isSpray, gl, spray]);
 
-  const handleMouseUp = useCallback((event : ThreeEvent<PointerEvent>) => {
+  const handleMouseUp = useCallback((event: ThreeEvent<PointerEvent>) => {
     setIsSpray(false);
-  },[]);
+  }, []);
 
+  // Starting KeyPoint Marking function.
+  const sphereGeometry = new THREE.SphereGeometry(0.05, 16, 16); // Small sphere
+  const sphereMaterial = new THREE.MeshBasicMaterial({ color: 'purple' });
 
-  //Starting KeyPoint Marking function.
-const sphereGeometry = new THREE.SphereGeometry(0.05, 16, 16); // Small sphere
-const sphereMaterial = new THREE.MeshBasicMaterial({ color: 'purple' });
+  useEffect(() => {
+    const handlePointerClick = (event: MouseEvent) => {
+      if (!meshRef.current || tool !== 'keypoint') return;
 
-useEffect(() => {
-  const handlePointerClick = (event: MouseEvent) => {
-    if (!meshRef.current || tool !== 'keypoint') return;
+      const rect = gl.domElement.getBoundingClientRect();
+      const mousePosition = new THREE.Vector2(
+        ((event.clientX - rect.left) / rect.width) * 2 - 1,
+        -((event.clientY - rect.top) / rect.height) * 2 + 1
+      );
 
-    const rect = gl.domElement.getBoundingClientRect();
-    const mousePosition = new THREE.Vector2(
-      ((event.clientX - rect.left) / rect.width) * 2 - 1,
-      -((event.clientY - rect.top) / rect.height) * 2 + 1
-    );
+      // Update raycaster with the mouse position and camera
+      raycasterRef.current.setFromCamera(mousePosition, camera);
 
-    // Update raycaster with the mouse position and camera
-    raycasterRef.current.setFromCamera(mousePosition, camera);
+      // Raycast to find intersections with the mesh
+      const intersects = raycasterRef.current.intersectObject(meshRef.current, true);
 
-    // Raycast to find intersections with the mesh
-    const intersects = raycasterRef.current.intersectObject(meshRef.current, true);
+      if (intersects.length > 0) {
+        const intersection = intersects[0];
+        const localPoint = intersection.point.clone(); // The point of intersection
 
-    if (intersects.length > 0) {
-      const intersection = intersects[0];
-      const localPoint = intersection.point.clone(); // The point of intersection
+        // Apply object matrix world to get the correct local position
+        const inverseMatrix = new THREE.Matrix4();
+        inverseMatrix.copy(meshRef.current.matrixWorld).invert(); // Invert the world matrix
+        localPoint.applyMatrix4(inverseMatrix); // Transform point into local coordinates
 
-      // Apply object matrix world to get the correct local position
-      const inverseMatrix = new THREE.Matrix4();
-      inverseMatrix.copy(meshRef.current.matrixWorld).invert(); // Invert the world matrix
-      localPoint.applyMatrix4(inverseMatrix); // Transform point into local coordinates
+        // Create a precise sphere at the local intersection point
+        const preciseSphere = new THREE.Mesh(sphereGeometry, sphereMaterial);
+        preciseSphere.position.copy(localPoint); // Apply precise local point
+        meshRef.current.add(preciseSphere); // Add sphere to the mesh in local space
 
-      // Create a precise sphere at the local intersection point
-      const preciseSphere = new THREE.Mesh(sphereGeometry, sphereMaterial);
-      preciseSphere.position.copy(localPoint); // Apply precise local point
-      meshRef.current.add(preciseSphere); // Add sphere to the mesh in local space
+        // Debugging log to show precise coordinates
+        console.log(`Clicked point (local):\nX: ${localPoint.x.toFixed(2)}\nY: ${localPoint.y.toFixed(2)}\nZ: ${localPoint.z.toFixed(2)}`);
+      }
+    };
 
-      // Debugging log to show precise coordinates
-      console.log(`Clicked point (local):\nX: ${localPoint.x.toFixed(2)}\nY: ${localPoint.y.toFixed(2)}\nZ: ${localPoint.z.toFixed(2)}`);
+    if (tool === 'keypoint') {
+      window.addEventListener('click', handlePointerClick);
     }
-  };
 
-  if (tool === 'keypoint') {
-    window.addEventListener('click', handlePointerClick);
-  }
-
-  return () => {
-    window.removeEventListener('click', handlePointerClick);
-  };
-}, [tool, camera, gl, meshRef]);
-
-
-
+    return () => {
+      window.removeEventListener('click', handlePointerClick);
+    };
+  }, [tool, camera, gl, meshRef]);
 
   return (
     <>
       <ambientLight intensity={0.5} />
       <spotLight position={[10, 15, 10]} angle={0.3} />
       <mesh ref={meshRef} onPointerDown={handleMouseDown} onPointerMove={handleMouseMove} onPointerUp={handleMouseUp} />
-      <OrbitControls  enableRotate={tool === 'pan'}  enableZoom  enablePan  rotateSpeed={1.0}/>
-      <lineSegments  ref={wireframeRef} material={new LineBasicMaterial({ color: 'white' })}  />
+      <OrbitControls enableRotate={tool === 'pan'} enableZoom enablePan rotateSpeed={1.0} />
+      <lineSegments ref={wireframeRef} material={new LineBasicMaterial({ color: 'white' })} />
     </>
   );
 };

--- a/capstone-project/src/components/ModelDisplay.tsx
+++ b/capstone-project/src/components/ModelDisplay.tsx
@@ -184,33 +184,14 @@ const ModelContent: React.FC<ModelDisplayProps> = ({ modelData }) => {
         preciseSphere.position.copy(localPoint); // Apply precise local point
         meshRef.current.add(preciseSphere); // Add sphere to the mesh in local space
 
-        // Retrieve the existing data from Zustand (model-colors-storage)
-        const storedData = JSON.parse(localStorage.getItem('model-colors-storage') || '{}');
+      // Use Zustand store to update the keypoints for the current modelId
+      useModelStore.getState().setKeypoint(modelId, { x: localPoint.x, y: localPoint.y, z: localPoint.z }, 'purple');
 
-        // Access model-specific data
-        const modelData = storedData[modelId] || { states: {}, keypoints: [] };
-
-        // Update keypoints array
-        const updatedKeypoints = [...(modelData.keypoints || []), { position: localPoint, color: 'purple' }];
-
-        // Update model data with new keypoints, preserving states (spray data)
-        const updatedModelData = {
-          ...modelData,
-          keypoints: updatedKeypoints,
-        };
-
-        // Update the overall storage object
-        const updatedStorage = {
-          ...storedData,
-          [modelId]: updatedModelData,
-        };
-
-        // Save updated data back to local storage under 'model-colors-storage'
-        localStorage.setItem('model-colors-storage', JSON.stringify(updatedStorage));
-
-       // Debugging log to show precise coordinates
-        console.log(`Clicked point (local):\nX: ${localPoint.x.toFixed(2)}\nY: ${localPoint.y.toFixed(2)}\nZ: ${localPoint.z.toFixed(2)}`);
-      }
+    
+      // Debugging log to show precise coordinates
+      console.log(`Clicked point (local):\nX: ${localPoint.x.toFixed(2)}\nY: ${localPoint.y.toFixed(2)}\nZ: ${localPoint.z.toFixed(2)}`);
+    }
+  
     };
 
     if (tool === 'keypoint') {

--- a/capstone-project/src/components/ModelDisplay.tsx
+++ b/capstone-project/src/components/ModelDisplay.tsx
@@ -28,6 +28,11 @@ const ModelContent: React.FC<ModelDisplayProps> = ({ modelData }) => {
   useEffect(() => {
     if (!meshRef.current || !wireframeRef.current) return;
 
+      // Remove previous keypoint spheres
+      while (meshRef.current.children.length > 0) {
+        meshRef.current.remove(meshRef.current.children[0]);
+      }
+
     const loader = new STLLoader();
     let geometry: BufferGeometry = loader.parse(modelData);
 
@@ -179,7 +184,31 @@ const ModelContent: React.FC<ModelDisplayProps> = ({ modelData }) => {
         preciseSphere.position.copy(localPoint); // Apply precise local point
         meshRef.current.add(preciseSphere); // Add sphere to the mesh in local space
 
-        // Debugging log to show precise coordinates
+        // Retrieve the existing data from Zustand (model-colors-storage)
+        const storedData = JSON.parse(localStorage.getItem('model-colors-storage') || '{}');
+
+        // Access model-specific data
+        const modelData = storedData[modelId] || { states: {}, keypoints: [] };
+
+        // Update keypoints array
+        const updatedKeypoints = [...(modelData.keypoints || []), { position: localPoint, color: 'purple' }];
+
+        // Update model data with new keypoints, preserving states (spray data)
+        const updatedModelData = {
+          ...modelData,
+          keypoints: updatedKeypoints,
+        };
+
+        // Update the overall storage object
+        const updatedStorage = {
+          ...storedData,
+          [modelId]: updatedModelData,
+        };
+
+        // Save updated data back to local storage under 'model-colors-storage'
+        localStorage.setItem('model-colors-storage', JSON.stringify(updatedStorage));
+
+       // Debugging log to show precise coordinates
         console.log(`Clicked point (local):\nX: ${localPoint.x.toFixed(2)}\nY: ${localPoint.y.toFixed(2)}\nZ: ${localPoint.z.toFixed(2)}`);
       }
     };

--- a/capstone-project/src/components/StateStore.tsx
+++ b/capstone-project/src/components/StateStore.tsx
@@ -5,12 +5,20 @@ interface ColorState {
   color: string;
 }
 
+interface KeypointState {
+  position: { x: number; y: number; z: number }; // 3D position of keypoint
+  color: string; // Color of the keypoint
+}
+
 interface ModelColorState {
   modelId: string;
   states: { [modelId: string]: { [vertexIndex: number]: ColorState } };// save the color of vertex
+  keypoints: { [modelId: string]: KeypointState[] }; // Save keypoint annotations
   setState: (modelId: string, vertexIndex: number, color: string) => void; // get the color information
+  setKeypoint: (modelId: string, position: { x: number; y: number; z: number }, color: string) => void; // Set keypoint at a specific 3D position
   setModelId: (modelId: string) => void;
 }
+
 
 const useModelStore = create<ModelColorState>()(
   devtools(
@@ -18,25 +26,43 @@ const useModelStore = create<ModelColorState>()(
       (set) => ({
         modelId: '',
         states: {},
+        keypoints: {},
+
+        // Set spray color for a vertex
         setState: (modelId, vertexIndex, color) =>
-          set(state => ({
+          set((state) => ({
             ...state,
             states: {
               ...state.states,
               [modelId]: {
                 ...(state.states[modelId] || {}),
-                [vertexIndex]: { color }
-              }
-            }
+                [vertexIndex]: { color },
+              },
+            },
           })),
-        setModelId: (id) =>
-          set(state => ({
+
+        // Set keypoint with position and color
+        setKeypoint: (modelId, position, color) =>
+          set((state) => ({
             ...state,
-            modelId: id
-          }))
+            keypoints: {
+              ...state.keypoints,
+              [modelId]: [
+                ...(state.keypoints[modelId] || []),
+                { position, color }, // Add new keypoint with its position and color
+              ],
+            },
+          })),
+
+        // Set current model ID
+        setModelId: (id) =>
+          set((state) => ({
+            ...state,
+            modelId: id,
+          })),
       }),
       {
-        name: 'model-colors-storage'
+        name: 'model-colors-storage',
       }
     )
   )


### PR DESCRIPTION
Modified StateSotre.tsx to add keypoint annotation saving under state->keypoint object
Modified ModelDisplay to: -Erase prevuios spheres from keypoint when it switch from one stl to another
                                            -Save keypoint annotation coordinates and color (for now the default is purple) on the local storage.
                                            -Load from local storage keypoints saving if a stl has prevouis keypoints annotations.
                                            -If conditional modification on spray to load spray annotation from local storage if there is a states records only (filter from keypoints annotation record).
